### PR TITLE
Disable detachInactiveScreens temporarily to avoid crash

### DIFF
--- a/src/navigation/tabs/TabsStack.tsx
+++ b/src/navigation/tabs/TabsStack.tsx
@@ -62,6 +62,7 @@ const TabsStack = () => {
   return (
     <Tab.Navigator
       initialRouteName={TabsScreens.HOME}
+      detachInactiveScreens={false}
       screenOptions={({route}) => ({
         headerShown: false,
         tabBarStyle: {


### PR DESCRIPTION
Android on new arch crashing when switching tabs multiple times due to bug in one of the navigation dependencies. Disabling this flag seems to avoid the crash for now.